### PR TITLE
Raise control thread priority

### DIFF
--- a/src/cfmarslab/control.py
+++ b/src/cfmarslab/control.py
@@ -5,6 +5,7 @@ from threading import Thread, Event, Lock
 from typing import Optional, List
 
 from .models import SharedState
+from .utils import set_realtime_priority
 
 
 class UDPInput:
@@ -26,6 +27,7 @@ class UDPInput:
         self._running.set()
         self._thread = Thread(target=self._run, daemon=True)
         self._thread.start()
+        set_realtime_priority(self._thread.ident)  # reduce jitter; may require admin rights
 
     def stop(self):
         self._running.clear()
@@ -153,6 +155,7 @@ class SetpointLoop:
         self._run_flag.set()
         self._thread = Thread(target=self._run, daemon=True)
         self._thread.start()
+        set_realtime_priority(self._thread.ident)  # reduce jitter; may require admin rights
 
     def stop(self):
         self._run_flag.clear()
@@ -234,6 +237,7 @@ class PWMSetpointLoop:
         self._run_flag.set()
         self._thread = Thread(target=self._run, daemon=True)
         self._thread.start()
+        set_realtime_priority(self._thread.ident)  # reduce jitter; may require admin rights
 
     def stop(self):
         self._run_flag.clear()

--- a/src/cfmarslab/utils.py
+++ b/src/cfmarslab/utils.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Utility helpers for cfmarslab."""
+
+import os
+from typing import Optional
+
+try:  # psutil is optional
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    psutil = None  # type: ignore
+
+
+def set_realtime_priority(thread_id: Optional[int]) -> None:
+    """Attempt to raise the scheduling priority of ``thread_id``.
+
+    Elevated priority can reduce control-loop jitter but may require
+    administrator/root privileges.  Unsupported platforms or failures are
+    silently ignored.
+    """
+
+    if thread_id is None:
+        return
+
+    try:
+        if os.name == "posix":
+            # Try POSIX real-time FIFO scheduling
+            try:
+                param = os.sched_param(10)
+                os.sched_setscheduler(thread_id, os.SCHED_FIFO, param)
+                return
+            except Exception:
+                pass
+
+        if psutil is None:
+            return
+
+        proc = psutil.Process()
+        if os.name == "nt":
+            # Windows: raise whole process priority class
+            try:
+                proc.nice(psutil.REALTIME_PRIORITY_CLASS)
+            except Exception:
+                pass
+        else:
+            # Fallback: lower nice value for the process
+            try:
+                proc.nice(-10)
+            except Exception:
+                pass
+    except Exception:
+        # Any failure is swallowed: this is best-effort only
+        pass
+


### PR DESCRIPTION
## Summary
- bump realtime priority for UDP input, setpoint, and PWM threads
- add `set_realtime_priority` utility with cross-platform fallbacks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cd4010f8c83309fb8498d4bdba910