### PR TITLE
Lazy initialize Crazyflie drivers before link setup

### DIFF
--- a/src/cfmarslab/link.py
+++ b/src/cfmarslab/link.py
@@ -12,7 +12,15 @@ from cflib.utils.power_switch import PowerSwitch
 from .models import SharedState
 from .config import Controls
 
-cflib.crtp.init_drivers()
+_drivers_initialized = False
+
+
+def init_drivers_once() -> None:
+    """Initialize CRTP drivers a single time."""
+    global _drivers_initialized
+    if not _drivers_initialized:
+        cflib.crtp.init_drivers(enable_debug_driver=False)
+        _drivers_initialized = True
 
 class LinkManager:
     """Manage Crazyflie link + minimal telemetry (VBAT, optional RSSI/latency)."""
@@ -29,6 +37,7 @@ class LinkManager:
         self._arm_param: str | None = None
 
     def connect(self):
+        init_drivers_once()
         # establish link
         self.scf = SyncCrazyflie(self.uri, cf=Crazyflie(rw_cache="./cache"))
         self.scf.__enter__()  # manual context enter to keep handle

--- a/src/cfmarslab/ui.py
+++ b/src/cfmarslab/ui.py
@@ -8,7 +8,7 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 
 from .models import SharedState
 from .config import load_config, save_config
-from .link import LinkManager
+from .link import LinkManager, init_drivers_once
 from .control import UDPInput, SetpointLoop, PWMSetpointLoop, PWMUDPReceiver
 from .vicon import ViconUDP51001
 import cflib.crtp
@@ -960,7 +960,7 @@ class App(tk.Tk):
         """Keep console messages as requested."""
         try:
             self.log("Scanning for Crazyradio/Crazyflie...")
-            cflib.crtp.init_drivers(enable_debug_driver=False)
+            init_drivers_once()
             found = cflib.crtp.scan_interfaces()
             uris = [u for (u, _d) in (found or [])]
             self.log(f"Scan complete: found {len(uris)} device(s)")


### PR DESCRIPTION
## Summary
- Add `init_drivers_once` helper and remove eager driver init
- Ensure `LinkManager.connect` and UI scanning lazily initialize CRTP drivers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a054fe22e883309ae79c6b33463dc5