### PR TITLE
Use perf_counter for KPI timing

### DIFF
--- a/src/cfmarslab/ui.py
+++ b/src/cfmarslab/ui.py
@@ -1,4 +1,5 @@
 import socket, struct, threading, time, queue, logging, sys, traceback
+from time import perf_counter
 import tkinter as tk
 from tkinter import ttk, scrolledtext
 from collections import deque
@@ -1006,7 +1007,7 @@ class App(tk.Tk):
             self.lbl_arm_state.config(text="—")
 
         # control timing KPIs and actual rates (update <=1Hz)
-        now = time.time()
+        now = perf_counter()
         if now - getattr(self, "_last_kpi_update", 0.0) >= 1.0:
             try:
                 loop = None


### PR DESCRIPTION
## Summary
- use high-resolution `perf_counter` in UI KPI updates for consistent timing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a60386d3c48330a86e365101630b83