### PR TITLE
Gracefully stop UDP input thread

### DIFF
--- a/src/cfmarslab/control.py
+++ b/src/cfmarslab/control.py
@@ -24,8 +24,11 @@ class UDPInput:
 
     # --- public API ---
     def start(self):
-        if self._thread and self._thread.is_alive():
-            return
+        if self._thread:
+            if self._thread.is_alive():
+                return
+            # cleanup stale thread reference
+            self._thread = None
         self._running.set()
         self._thread = Thread(target=self._run, daemon=True)
         self._thread.start()
@@ -33,6 +36,9 @@ class UDPInput:
 
     def stop(self):
         self._running.clear()
+        if self._thread:
+            self._thread.join(timeout=1.0)
+            self._thread = None
 
     def set_rate(self, hz: int):
         with self._rate_lock:


### PR DESCRIPTION
## Summary
- ensure UDPInput.stop waits for thread termination and clears reference
- allow UDPInput.start to restart thread after prior stop

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60bdd6b3c833093db88d540933e1a