### PR TITLE
Handle big-endian Vicon UDP packets reliably

### DIFF
--- a/src/cfmarslab/config.py
+++ b/src/cfmarslab/config.py
@@ -33,6 +33,13 @@ class RT:
     SPIN_NS: int = 150_000     # busy-wait window (nanoseconds)
     PIN_CPU: int | None = None # set e.g. 2 to bind to core 2
 
+@dataclass(frozen=True)
+class Vicon:
+    PORT: int = 8889
+    # Preferred format; thread will still auto-fallback by packet length:
+    PREFERRED: str = ">6d"     # big-endian 6 doubles
+    # Valid alternatives: ">6f"
+
 @dataclass
 class AppConfig:
     recent_uris: list[str]

--- a/tests/test_vicon.py
+++ b/tests/test_vicon.py
@@ -4,7 +4,7 @@ import time
 import pytest
 
 from cfmarslab.vicon import ViconUDP51001
-from cfmarslab.ui import decode_pose_be_doubles
+from cfmarslab.ui import decode_vicon_be
 
 
 def test_vicon_udp_receives_packet(tmp_path):
@@ -34,14 +34,17 @@ def test_vicon_udp_receives_packet(tmp_path):
         assert abs(r - v) < 1e-5
 
 
-def test_decode_pose_be_doubles():
+def test_decode_vicon_be():
     vals = (1.0, 2.0, 3.0, 0.1, 0.2, 0.3)
     data = struct.pack(">6d", *vals)
-    res = decode_pose_be_doubles(data)
-    for r, v in zip(res, vals):
+    x, y, z, rx, ry, rz, fmt = decode_vicon_be(data)
+    assert fmt == ">6d"
+    for r, v in zip((x, y, z, rx, ry, rz), vals):
         assert abs(r - v) < 1e-9
-    res = decode_pose_be_doubles(data + b"extra")
-    for r, v in zip(res, vals):
-        assert abs(r - v) < 1e-9
+    data_f = struct.pack(">6f", *vals)
+    x, y, z, rx, ry, rz, fmt = decode_vicon_be(data_f)
+    assert fmt == ">6f"
+    for r, v in zip((x, y, z, rx, ry, rz), vals):
+        assert abs(r - v) < 1e-5
     with pytest.raises(ValueError):
-        decode_pose_be_doubles(b"\x00" * 10)
+        decode_vicon_be(b"\x00" * 10)


### PR DESCRIPTION
## Summary
- add Vicon config with default port and preferred big-endian format
- implement `decode_vicon_be` supporting big-endian doubles and float32 fallback
- harden Vicon listener thread and UI to use new decoder and guard socket lifecycle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a724d17068833091ca1fa8290153f8