### PR TITLE
Threaded restart workflow with optional auto reconnect

### DIFF
--- a/src/cfmarslab/ui.py
+++ b/src/cfmarslab/ui.py
@@ -1012,10 +1012,7 @@ class App(tk.Tk):
         threading.Thread(target=_ramp_4pid if self._is_4pid_mode_active() else _ramp_2pid, daemon=True).start()
 
     def _on_restart(self):
-        import threading
-
-        t = threading.Thread(target=self._restart_worker, daemon=True)
-        t.start()
+        threading.Thread(target=self._restart_worker, daemon=True).start()
 
     def _status(self, msg: str):
         try:
@@ -1030,7 +1027,6 @@ class App(tk.Tk):
         return self._rebuild_uri()
 
     def _restart_worker(self):
-        import time, sys
         from cflib.utils.power_switch import PowerSwitch
 
         try:
@@ -1063,7 +1059,7 @@ class App(tk.Tk):
                 pass
 
             # 3) Auto-reconnect if enabled
-            if getattr(self.cfg, "auto_reconnect", True):
+            if self.cfg.auto_reconnect:
                 self._status("Reconnecting…")
                 try:
                     self.on_connect()


### PR DESCRIPTION
## Summary
- Run restart logic in a background thread
- Power-cycle using PowerSwitch, clear Windows UDP ports, and auto-reconnect when enabled

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8a90cc05083309a6da6f74c8bb394