### PR TITLE
Make takeoff thrust threshold configurable

### DIFF
--- a/src/cfmarslab/config.py
+++ b/src/cfmarslab/config.py
@@ -16,6 +16,7 @@ class Rates:
 class Safety:
     VBAT_BLOCK: float = 3.7    # 低於此電壓禁止起飛
     VBAT_AUTO_LAND: float = 3.5
+    TAKEOFF_THRUST: int = 38000  # 起飛油門門檻
 
 @dataclass(frozen=True)
 class Controls:

--- a/tests/test_setpointloop.py
+++ b/tests/test_setpointloop.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from cfmarslab.control import SetpointLoop
+from cfmarslab.models import SharedState
+
+
+class DummyLink:
+    def __init__(self):
+        self.sent = []
+
+    def send_setpoint(self, r, p, y, th):
+        self.sent.append((r, p, y, th))
+
+
+def test_setpointloop_min_thrust():
+    state = SharedState()
+    link = DummyLink()
+    loop = SetpointLoop(state, link, min_thrust=38000)
+    loop._sender.enqueue = lambda func, *args, **kwargs: func(*args, **kwargs)
+
+    with state.lock:
+        state.vbat = 4.0
+        state.rpyth.update({"roll": 1.0, "pitch": 2.0, "yaw": 3.0, "thrust": 37000})
+    loop._step()
+    assert link.sent[-1] == (0.0, 0.0, 0.0, 37000)
+
+    with state.lock:
+        state.rpyth.update({"roll": 1.0, "pitch": 2.0, "yaw": 3.0, "thrust": 39000})
+    loop._step()
+    assert link.sent[-1] == (1.0, 2.0, 3.0, 39000)


### PR DESCRIPTION
## Summary
- allow SetpointLoop to accept configurable `min_thrust` with default 38000
- expose default takeoff threshold via `Safety.TAKEOFF_THRUST`
- test that RPY commands are blocked until thrust exceeds this threshold

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aed347fa6883308674003d3e6b9721