### PR TITLE
Refine takeoff and landing workflow

### DIFF
--- a/src/cfmarslab/config.py
+++ b/src/cfmarslab/config.py
@@ -19,6 +19,14 @@ class Safety:
     TAKEOFF_THRUST: int = 38000  # 起飛油門門檻
 
 @dataclass(frozen=True)
+class Landing:
+    """Default parameters for smooth landing ramps."""
+    MID_THRUST: int = 35000
+    RAMP1_TIME: float = 1.5
+    RAMP2_TIME: float = 0.5
+    STEPS: int = 10
+
+@dataclass(frozen=True)
 class Controls:
     ARM_PARAM_CANDIDATES: tuple[str, ...] = (
         "stabilizer.armed",

--- a/src/cfmarslab/models.py
+++ b/src/cfmarslab/models.py
@@ -23,6 +23,9 @@ class SharedState:
     stop_all: Event = field(default_factory=Event)
     stop_flight: Event = field(default_factory=Event)
     lock: Lock = field(default_factory=Lock)
+    # Active control mode and running state
+    active_mode: str | None = None
+    is_flying: Event = field(default_factory=Event)
 
     # Ring buffer for logs (UI plots)
     log_buf: Deque = field(default_factory=lambda: deque(maxlen=2000))


### PR DESCRIPTION
## Summary
- Rename main flight buttons to “Take off” and “Land” and remove manual arming controls
- Add mode-aware zeroing, auto-arming, and smooth landing routines for RPYT and PWM control
- Expose link utilities and shared state flags for connection, arming, and loop management

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aee72297e48330920b605eedc555d2