### PR TITLE
Integrate path streaming into XYZ → MATLAB panel

### DIFF
--- a/src/cfmarslab/control.py
+++ b/src/cfmarslab/control.py
@@ -718,7 +718,7 @@ def start_path(state: SharedState, rate_hz: int, base_xyz: tuple[float, float, f
     loop.start()
     _path_loop = loop
     with state.lock:
-        state.path_running = True
+        state.stream_running = True
         state.path_type = path_type
         state.path_params = dict(params)
         state.path_rate_hz = int(rate_hz)
@@ -733,7 +733,7 @@ def stop_path(state: SharedState):
         _path_loop.stop()
         _path_loop = None
     with state.lock:
-        state.path_running = False
+        state.stream_running = False
 
 
 def send_xyz_once(x: float, y: float, z: float):

--- a/src/cfmarslab/models.py
+++ b/src/cfmarslab/models.py
@@ -30,8 +30,8 @@ class SharedState:
     # Ring buffer for logs (UI plots)
     log_buf: Deque = field(default_factory=lambda: deque(maxlen=2000))
 
-    # --- Flight path streaming state ---
-    path_running: bool = False
+    # --- XYZ path streaming state ---
+    stream_running: bool = False
     path_type: str = "none"      # "none" | "circle" | "square"
     path_params: Dict[str, float] = field(default_factory=dict)
     path_rate_hz: int = 20


### PR DESCRIPTION
## Summary
- embed Circle and Square path controls into existing XYZ → MATLAB group
- unify XYZ streaming through FlightPathLoop with static and path options
- track path streaming state in shared model

## Testing
- `python -m py_compile src/cfmarslab/control.py src/cfmarslab/models.py src/cfmarslab/ui.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aef79bcd848330aedf9bfabd3a6b26