### PR TITLE
Add 3D path preview apply for Crazyflie GUI

### DIFF
--- a/src/cfmarslab/config.py
+++ b/src/cfmarslab/config.py
@@ -57,6 +57,18 @@ class PathCfg:
     MIN_HZ: int = 1
     MAX_HZ: int = 200
 
+
+@dataclass(frozen=True)
+class PreviewCfg:
+    """Defaults for XYZ path preview rendering."""
+    CIRCLE_SAMPLES: int = 200
+    SQUARE_EDGE_SAMPLES: int = 50
+    TARGET_COLOR: str = "tab:red"
+    PATH_COLOR: str = "tab:blue"
+    CENTER_COLOR: str = "tab:gray"
+    TARGET_SIZE: int = 60
+    AXIS_MARGIN_FRAC: float = 0.1  # 10% margin around preview
+
 @dataclass
 class AppConfig:
     recent_uris: list[str]

--- a/src/cfmarslab/models.py
+++ b/src/cfmarslab/models.py
@@ -32,6 +32,7 @@ class SharedState:
 
     # --- XYZ path streaming state ---
     stream_running: bool = False
+    # Last path selection applied from the UI
     path_type: str = "none"      # "none" | "circle" | "square"
     path_params: Dict[str, float] = field(default_factory=dict)
     path_rate_hz: int = 20


### PR DESCRIPTION
## Summary
- add PreviewCfg with sampling and colour defaults
- expose pure preview sampling helpers for none, circle and square paths
- add Apply button to XYZ→MATLAB panel to validate input, store state and draw static path preview

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aefb41bccc83308221562126420fa2