### PR TITLE
Send neutral RPYT frame before landing

### DIFF
--- a/src/cfmarslab/link.py
+++ b/src/cfmarslab/link.py
@@ -69,7 +69,8 @@ class LinkManager:
     def get_cf(self) -> Optional[Crazyflie]:
         return self.cf
 
-    def get_commander(self):
+    def get_commander(self) -> Optional[object]:
+        """Return the Crazyflie commander if available, else None."""
         cf = self.cf
         return cf.commander if cf else None
 

--- a/src/cfmarslab/ui.py
+++ b/src/cfmarslab/ui.py
@@ -1250,8 +1250,10 @@ class App(tk.Tk):
                 self.log(f"Emergency stop failed: {e}")
 
     def land(self):
-        mode = "pwm" if self._is_4pid_mode_active() else "rpyt"
-        controller.land(mode, self.state_model, self.link)
+        if self._is_4pid_mode_active():
+            self._pwm_stop()
+        else:
+            self._sp_stop()
 
     def _on_restart(self):
         threading.Thread(target=self._restart_worker, daemon=True).start()


### PR DESCRIPTION
## Summary
- ensure RPYT land sequence transmits a neutral setpoint immediately
- expose `get_commander()` on the link manager
- wire Land button to use existing stop helpers in the UI

## Testing
- `python3 -m py_compile src/cfmarslab/control.py src/cfmarslab/link.py src/cfmarslab/ui.py`
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af2fc42538833080dbe621c84bf890