### PR TITLE
Add live current target marker to 3D view

### DIFF
--- a/src/cfmarslab/models.py
+++ b/src/cfmarslab/models.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from threading import Event, Lock
 from collections import deque
-from typing import Dict, Deque, Tuple
+from typing import Dict, Deque, Tuple, Optional
 
 from .config import PathCfg
 
@@ -44,3 +44,20 @@ class SharedState:
     path_index: float = 0.0      # for square
     path_actual_rate: float = 0.0
     path_error: str = ""
+
+
+# --- last streamed XYZ for UI marker -------------------------------------
+_last_stream_xyz: Optional[Tuple[float, float, float]] = None
+_lock = Lock()
+
+
+def set_last_stream_xyz(v: Optional[Tuple[float, float, float]]) -> None:
+    """Atomically store the most recent XYZ sent to MATLAB."""
+    with _lock:
+        globals()["_last_stream_xyz"] = v
+
+
+def get_last_stream_xyz() -> Optional[Tuple[float, float, float]]:
+    """Return the last streamed XYZ, or None if unavailable."""
+    with _lock:
+        return _last_stream_xyz


### PR DESCRIPTION
## Summary
- Track and store last streamed XYZ coordinates thread-safely
- Broadcast each streamed XYZ to the shared state and clear on stop
- Render a persistent green marker in the 3D view that updates with streamed targets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af38c40bd0833098fc11117d0f4499