### PR TITLE
Send zero RPYT packet after landing

### DIFF
--- a/src/cfmarslab/control.py
+++ b/src/cfmarslab/control.py
@@ -821,10 +821,11 @@ def land(mode: str, state: SharedState, link: LinkManager):
         state.is_flying.clear()
 
     clear_udp_8888()
+    send_udp_rpyt_zero()
     if mode == "rpyt":
-        logging.info("Landing complete, RPYT=0 sent, port 8888 cleared.")
+        logging.info("Landing complete, zero RPYT packet dispatched, port 8888 cleared.")
     else:
-        logging.info("Landing complete (PWM), port 8888 cleared.")
+        logging.info("Landing complete (PWM), zero RPYT packet dispatched, port 8888 cleared.")
     return True
 
 
@@ -890,3 +891,14 @@ def clear_udp_8888():
         logging.debug("[UDP] Cleared port 8888 after Stop")
     except OSError:
         pass
+
+
+def send_udp_rpyt_zero():
+    """Send a single zeroed RPYT packet to localhost UDP port 8888."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        pkt = struct.pack("<4f", 0.0, 0.0, 0.0, 0.0)
+        sock.sendto(pkt, ("127.0.0.1", 8888))
+        logging.debug("[UDP] Sent zero RPYT packet to port 8888")
+    finally:
+        sock.close()


### PR DESCRIPTION
## Summary
- Dispatch a zeroed RPYT UDP packet after landing to ensure motors are safe
- Add helper to send zero RPYT packets and refactor landing routine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af39cd677c8330895070f71d5bec6d