### PR TITLE
Implement immediate emergency stop and update safety UI

### DIFF
--- a/src/cfmarslab/models.py
+++ b/src/cfmarslab/models.py
@@ -82,6 +82,15 @@ def get_last_rpyt():
         return _last_rpyt
 
 
+def clear_stop_flags(state: SharedState) -> None:
+    """Reset stop events so control loops may be restarted."""
+    try:
+        state.stop_all.clear()
+        state.stop_flight.clear()
+    except Exception:
+        pass
+
+
 def set_last_stream_xyz(v: Optional[Tuple[float, float, float]]) -> None:
     """Atomically store the most recent XYZ sent to MATLAB."""
     with _stream_lock:


### PR DESCRIPTION
## Summary
- Remove Land button from Safety panel, leaving Emergency stop and Clear UDP 8888.
- Add UI helpers and wire Emergency stop to controller logic to reset RPYT and buttons.
- Implement hard emergency stop in controller with loop termination and state reset; expose helper to clear stop flags.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4d597ab48330b48701ed64ba353f