### PR TITLE
Use CRTP 4×PWM port for 4‑PID control

### DIFF
--- a/src/cfmarslab/link.py
+++ b/src/cfmarslab/link.py
@@ -74,6 +74,18 @@ class LinkManager:
         cf = self.cf
         return cf.commander if cf else None
 
+    def get_link(self) -> Optional[object]:
+        """Return the low-level link object if available."""
+        cf = self.cf
+        if cf and getattr(cf, "link", None):
+            return cf.link
+        try:
+            if self.scf and getattr(self.scf.cf, "link", None):
+                return self.scf.cf.link
+        except Exception:
+            pass
+        return None
+
     def send_arming_request(self, value: bool) -> bool:
         cf = self.cf
         try:

--- a/src/cfmarslab/models.py
+++ b/src/cfmarslab/models.py
@@ -58,6 +58,9 @@ _stream_lock = Lock()
 _lock = threading.Lock()
 _accept_udp_8888 = False
 _last_rpyt = (0.0, 0.0, 0.0, 0.0)
+_last_pwm = (0, 0, 0, 0)
+_pwm_running = False
+_pwm_actual_rate = 0.0
 
 
 def set_accept_udp_8888(v: bool):
@@ -80,6 +83,39 @@ def set_last_rpyt(rpyt_tuple):
 def get_last_rpyt():
     with _lock:
         return _last_rpyt
+
+
+def set_last_pwm(pwm_tuple):
+    global _last_pwm
+    with _lock:
+        _last_pwm = tuple(int(x) for x in pwm_tuple)
+
+
+def get_last_pwm():
+    with _lock:
+        return _last_pwm
+
+
+def set_pwm_running(v: bool):
+    global _pwm_running
+    with _lock:
+        _pwm_running = bool(v)
+
+
+def get_pwm_running() -> bool:
+    with _lock:
+        return _pwm_running
+
+
+def set_pwm_actual_rate(v: float):
+    global _pwm_actual_rate
+    with _lock:
+        _pwm_actual_rate = float(v)
+
+
+def get_pwm_actual_rate() -> float:
+    with _lock:
+        return _pwm_actual_rate
 
 
 def clear_stop_flags(state: SharedState) -> None:


### PR DESCRIPTION
## Summary
- Send 4×PWM motor commands directly over CRTP port 0x0A with fallback link support
- Track last PWM values, loop status and actual rate in models for UI display
- Wire 4-PID UI controls and safety actions to new PWM loop and zeroing helpers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1a7d2483c833089aadddb5b5c07b6