### PR TITLE
Add MATLAB helper for UDP PWM sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,26 @@ This is project is also suit to anyone who is bridging  **MATLAB**  and **Crazyf
 - **3D View & Controls**
   - A Matplotlib 3D scene with tight margins occupies the right pane; vertical **Elevation** and horizontal **Azimuth** sliders rotate the view interactively
 
+### MATLAB/Simulink UDP PWM Sender
+
+The GUI's PWM receiver listens on `127.0.0.1:8888` and updates only when a frame of eight bytes is received. Each frame must encode four unsigned 16-bit motor values in little-endian order (`<4H>`).
+
+**MATLAB helper**
+
+```matlab
+bytes = pack_pwm_u16_bytes(m1, m2, m3, m4);
+u = udpport("byte", "OutputDatagramSize", 8);
+write(u, bytes, "uint8", "127.0.0.1", 8888);
+```
+
+**Simulink blocks**
+
+1. Cast each motor signal to `uint16`.
+2. Use a *Byte Pack* block configured for four `uint16` elements with little-endian output (`uint8[8]`).
+3. Connect to a *UDP Send* block set for packet size `8`, remote address `127.0.0.1`, and port `8888`.
+
+The GUI ignores frames that are not exactly eight bytes—for example, sending four `single` values (16 bytes) will be discarded. If the port becomes busy, use **Clear UDP 8888** in the GUI to free it before retrying.
+
 ### Typical workflow
 
 1. Launch the GUI, set radio channel/bitrate/address, and click **Connect**.  

--- a/matlab/pack_pwm_u16_bytes.m
+++ b/matlab/pack_pwm_u16_bytes.m
@@ -1,0 +1,23 @@
+function bytes = pack_pwm_u16_bytes(m1, m2, m3, m4)
+%PACK_PWM_U16_BYTES Convert four motor values into 8 raw bytes.
+%   BYTES = PACK_PWM_U16_BYTES(M1,M2,M3,M4) returns a uint8 vector of
+%   length 8 encoded as little-endian <4H> suitable for the GUI's UDP 8888
+%   PWM receiver.
+%
+%   Each input is cast to UINT16 before typecasting to UINT8. On
+%   big-endian hosts, values are byte-swapped to maintain little-endian
+%   network order.
+%
+%   Example:
+%       u = udpport("byte", "OutputDatagramSize", 8);
+%       write(u, pack_pwm_u16_bytes(1000,2000,3000,4000), "uint8", "127.0.0.1", 8888);
+%
+%   See also TYPECAST, UINT16, SWAPBYTES.
+
+vals = uint16([m1, m2, m3, m4]);
+% Detect host endianness; swap if running on big-endian hardware.
+if ~isequal(typecast(uint16(1), 'uint8'), uint8([1 0]))
+    vals = swapbytes(vals);
+end
+bytes = typecast(vals, 'uint8');
+end


### PR DESCRIPTION
## Summary
- document how to send PWM via UDP 8888 from MATLAB/Simulink
- provide `pack_pwm_u16_bytes.m` helper that packs four uint16 motors into 8 bytes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1d476fc508330a90f6294cea18221